### PR TITLE
SettingsPathDisplay & PaletteTextInput

### DIFF
--- a/src/Modules/Misc/PaletteTextInput.cs
+++ b/src/Modules/Misc/PaletteTextInput.cs
@@ -1,4 +1,6 @@
 ﻿namespace RegionKit
+﻿using DevInterface;
+
 {
 	internal class PaletteTextInput
 	{
@@ -27,7 +29,7 @@
 			{
 				//todo: probably breaks
 				var paletteField = new PaletteField(self);
-				var strfield = new ManagedStringControl(paletteField, new ManagedData(null!, new ManagedField[] { paletteField }), null, 0f);
+				var strfield = new ManagedStringControl(paletteField, new ManagedData(null!, new ManagedField[] { paletteField }), self, 0f);
 				strfield.ClearSprites();
 				strfield.subNodes[1] = self.subNodes.Find(e => e.IDstring == "Number");
 				self.subNodes.Add(strfield);

--- a/src/Modules/Misc/SettingsPathDisplay.cs
+++ b/src/Modules/Misc/SettingsPathDisplay.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DevInterface;
+
+namespace RegionKit.Modules.Misc
+{
+	internal class SettingsPathDisplay
+	{
+		internal static void Apply()
+		{
+			On.DevInterface.Page.ctor += Page_ctor;
+		}
+
+		internal static void Undo()
+		{
+			On.DevInterface.Page.ctor -= Page_ctor;
+		}
+
+		private static void Page_ctor(On.DevInterface.Page.orig_ctor orig, DevInterface.Page self, DevInterface.DevUI owner, string IDstring, DevInterface.DevUINode parentNode, string name)
+		{
+			orig(self, owner, IDstring, parentNode, name);
+
+			string settingsPath = "Settings Path: " + self.RoomSettings.filePath;
+			self.subNodes.Add(new DevUILabel(owner, "Settings_Path", null, new Vector2(1330f - 6f * (float)settingsPath.Length, 20f), 20f + 6f * (float)settingsPath.Length, settingsPath));
+		}
+
+	}
+}

--- a/src/Modules/Misc/_Module.cs
+++ b/src/Modules/Misc/_Module.cs
@@ -19,6 +19,8 @@ internal static class _Module
 		ArenaFixes.ApplyHooks();
 		ExtendedGates.Enable();
 		SuperstructureFusesFix.Patch();
+		PaletteTextInput.Apply();
+		SettingsPathDisplay.Apply();
 		
 	}
 	public static void Disable()
@@ -28,5 +30,7 @@ internal static class _Module
 		ArenaFixes.UndoHooks();
 		ExtendedGates.Disable();
 		SuperstructureFusesFix.Disable();
+		PaletteTextInput.Undo();
+		SettingsPathDisplay.Undo();
 	}
 }


### PR DESCRIPTION
Fixes PaletteTextInput (requires POM update)
Adds a DevUILabel at the bottom of the devtools menu which shows where the devtools settings will be saved to