### PR TITLE
Stencil Buffer Enabler

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ Automatically loads all atlases from assetpath `assets/regionkit` (recursively)
 - Isbjorn52
 	- Gate Customization
 
+- Xan
+	- Superstructure Fuses depth fix
+ 	- Shader stencil buffer enabler
+
 **Initial ExtendedGates authors**: Henpemaz (code); Mehri'Kairotep, Thalber, LB/M4rbleL1ne and Nautillo (spritework).
 
 ## Download

--- a/mod/modinfo.json
+++ b/mod/modinfo.json
@@ -1,7 +1,7 @@
 {
 	"id": "regionkit",
 	"name": "RegionKit",
-	"version": "3.13",
+	"version": "3.13.1",
 	"authors": "RegionKit team",
 	"description": "All-in-one custom region dependency pack.<LINE>Source code and detailed descriptions are hosted here: https://github.com/Rain-World-Modding/RegionKit<LINE>[b]Reporting bugs[/b]<LINE>If you have a problem to report, please do it via github issues, Rain World discord server, or leave a post on discussions under this workshop item. Try to first look if anyone has already reported similar problem, attach logs and other materials if relevant!<LINE>[b]Common issue and ways to fix[/b]<LINE>If the game crashes without logs, try manually deleting BepInEx folder and re-verifying game files.",
 	"requirements": [

--- a/mod/modinfo.json
+++ b/mod/modinfo.json
@@ -1,7 +1,7 @@
 {
 	"id": "regionkit",
 	"name": "RegionKit",
-	"version": "3.13.1",
+	"version": "3.13.2",
 	"authors": "RegionKit team",
 	"description": "All-in-one custom region dependency pack.<LINE>Source code and detailed descriptions are hosted here: https://github.com/Rain-World-Modding/RegionKit<LINE>[b]Reporting bugs[/b]<LINE>If you have a problem to report, please do it via github issues, Rain World discord server, or leave a post on discussions under this workshop item. Try to first look if anyone has already reported similar problem, attach logs and other materials if relevant!<LINE>[b]Common issue and ways to fix[/b]<LINE>If the game crashes without logs, try manually deleting BepInEx folder and re-verifying game files.",
 	"requirements": [

--- a/src/Mod.cs
+++ b/src/Mod.cs
@@ -6,7 +6,7 @@
 [BepInEx.BepInPlugin(MOD_GUID, MOD_FRIENDLYNAME, MOD_VERSION)]
 public class Mod : BepInEx.BaseUnityPlugin
 {
-	internal const string MOD_VERSION = "3.13";
+	internal const string MOD_VERSION = "3.13.1";
 	internal const string MOD_FRIENDLYNAME = "RegionKit";
 	internal const string MOD_GUID = "rwmodding.coreorg.rk";
 	internal const string RK_POM_CATEGORY = "RegionKit";

--- a/src/Mod.cs
+++ b/src/Mod.cs
@@ -6,7 +6,7 @@
 [BepInEx.BepInPlugin(MOD_GUID, MOD_FRIENDLYNAME, MOD_VERSION)]
 public class Mod : BepInEx.BaseUnityPlugin
 {
-	internal const string MOD_VERSION = "3.13.1";
+	internal const string MOD_VERSION = "3.13.2";
 	internal const string MOD_FRIENDLYNAME = "RegionKit";
 	internal const string MOD_GUID = "rwmodding.coreorg.rk";
 	internal const string RK_POM_CATEGORY = "RegionKit";

--- a/src/Modules/CustomProjections/OverseerProperties.cs
+++ b/src/Modules/CustomProjections/OverseerProperties.cs
@@ -10,7 +10,7 @@ internal class OverseerProperties
 {
 	private static ConditionalWeakTable<Region.RegionParams, OverseerProperties> _AttachedProperties = new();
 
-	public static OverseerProperties GetOverseerProperties(Region p) => p != null ? _AttachedProperties.GetValue(p.regionParams, _ => new()) : new();
+	public static OverseerProperties GetOverseerProperties(Region? p) => p != null ? _AttachedProperties.GetValue(p.regionParams, _ => new()) : new();
 
 	public static void Apply()
 	{

--- a/src/Modules/CustomProjections/OverseerRecolor.cs
+++ b/src/Modules/CustomProjections/OverseerRecolor.cs
@@ -56,7 +56,7 @@ internal static class OverseerRecolor
 
 		if (!OverseerProperties.BaseIndex(id))
 		{
-			if (OverseerProperties.GetOverseerProperties(self.overseer.room.world.region).overseerColorLookup.TryGetValue(id, out var color))
+			if (OverseerProperties.GetOverseerProperties(self.OwnerRoom?.world.region).overseerColorLookup.TryGetValue(id, out var color))
 			{ return color; }
 		}
 		return orig(self);

--- a/src/Modules/Effects/_Module.cs
+++ b/src/Modules/Effects/_Module.cs
@@ -24,7 +24,7 @@ public static class _Module
 
 		RainWorld rainworld = CRW;
 		MossWaterRGBBuilder.__RegisterBuilder();
-		IceWaterBuilder.__RegisterBuilder();
+		//IceWaterBuilder.__RegisterBuilder();
 		MossWaterUnlit.MossLoadResources(rainworld);
 		MossWaterRGB.MossLoadResources(rainworld);
 

--- a/src/Modules/ShaderTools/ShaderBuffers.cs
+++ b/src/Modules/ShaderTools/ShaderBuffers.cs
@@ -35,12 +35,14 @@ namespace RegionKit.Modules.ShaderTools {
 		
 		private static void OnReinitializeRT(On.FScreen.orig_ReinitRenderTexture originalMethod, FScreen @this, int displayWidth) {
 			originalMethod(@this, displayWidth);
-			@this.renderTexture.depth = _hasStencilBuffer ? DEPTH_AND_STENCIL_BUFFER_BITS : @this.renderTexture.depth;
+			// Use this check in case another mod happens to enable the 32 bit buffer for whatever reason.
+			@this.renderTexture.depth = (_hasStencilBuffer && @this.renderTexture.depth < DEPTH_AND_STENCIL_BUFFER_BITS) ? DEPTH_AND_STENCIL_BUFFER_BITS : @this.renderTexture.depth;
 		}
 
 		private static void OnConstructingFScreen(On.FScreen.orig_ctor originalCtor, FScreen @this, FutileParams futileParams) {
 			originalCtor(@this, futileParams);
-			@this.renderTexture.depth = _hasStencilBuffer ? DEPTH_AND_STENCIL_BUFFER_BITS : @this.renderTexture.depth;
+			// Use this check in case another mod happens to enable the 32 bit buffer for whatever reason.
+			@this.renderTexture.depth = (_hasStencilBuffer && @this.renderTexture.depth < DEPTH_AND_STENCIL_BUFFER_BITS) ? DEPTH_AND_STENCIL_BUFFER_BITS : @this.renderTexture.depth;
 		}
 
 	}

--- a/src/Modules/ShaderTools/ShaderBuffers.cs
+++ b/src/Modules/ShaderTools/ShaderBuffers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine;
 
 namespace RegionKit.Modules.ShaderTools {
@@ -15,6 +15,13 @@ namespace RegionKit.Modules.ShaderTools {
 			On.FScreen.ctor += OnConstructingFScreen;
 			On.FScreen.ReinitRenderTexture += OnReinitializeRT;
 			_hasStencilBuffer = true;
+			if (Futile.screen != null) {
+				RenderTexture rt = Futile.screen.renderTexture;
+				if (rt.depth < DEPTH_AND_STENCIL_BUFFER_BITS) {
+					// Use this check in case another mod happens to enable the 32 bit buffer for whatever reason.
+					rt.depth = DEPTH_AND_STENCIL_BUFFER_BITS;
+				}
+			}
 		}
 
 		internal static void Uninitialize() {

--- a/src/Modules/ShaderTools/ShaderBuffers.cs
+++ b/src/Modules/ShaderTools/ShaderBuffers.cs
@@ -14,7 +14,7 @@ namespace RegionKit.Modules.ShaderTools {
 
 		/// <summary>
 		/// Requests that the stencil buffer is enabled, setting the depth bit count of the main screen's render texture to 24 bits.
-		/// Once at least one mod calls this, it will be permanently enabled and 
+		/// Once at least one mod calls this, it will be permanently enabled. 
 		/// </summary>
 		public static void RequestStencilBuffer() {
 			if (!_hasStencilBuffer && Futile.screen != null) {

--- a/src/Modules/ShaderTools/ShaderBuffers.cs
+++ b/src/Modules/ShaderTools/ShaderBuffers.cs
@@ -1,0 +1,41 @@
+using System;
+using UnityEngine;
+
+namespace RegionKit.Modules.ShaderTools {
+	public static class ShaderBuffers {
+
+		/// <summary>
+		/// The amount of bits needed to activate the stencil buffer.
+		/// </summary>
+		private const int DEPTH_AND_STENCIL_BUFFER_BITS = 24;
+
+		/// <summary>
+		/// Requests that the stencil buffer is enabled, setting the depth bit count of the main screen's render texture to 24 bits.
+    /// Once at least one mod calls this, it will be permanently enabled and 
+		/// </summary>
+		public static void RequestStencilBuffer() {
+			if (Futile.screen != null) {
+				RenderTexture rt = Futile.screen.renderTexture;
+				if (rt.depth < DEPTH_AND_STENCIL_BUFFER_BITS) {
+					rt.depth = DEPTH_AND_STENCIL_BUFFER_BITS;
+				}
+			}
+		}
+
+		internal static void Initialize() {
+			On.FScreen.ctor += OnConstructingFScreen;
+			On.FScreen.ReinitRenderTexture += OnReinitializeRT;
+		}
+
+		private static void OnReinitializeRT(On.FScreen.orig_ReinitRenderTexture originalMethod, FScreen @this, int displayWidth) {
+			originalMethod(@this, displayWidth);
+			@this.renderTexture.depth = _highestRequestedBits;
+		}
+
+		private static void OnConstructingFScreen(On.FScreen.orig_ctor originalCtor, FScreen @this, FutileParams futileParams) {
+			originalCtor(@this, futileParams);
+			@this.renderTexture.depth = _highestRequestedBits;
+		}
+
+	}
+}

--- a/src/Modules/ShaderTools/ShaderBuffers.cs
+++ b/src/Modules/ShaderTools/ShaderBuffers.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using UnityEngine;
 
 namespace RegionKit.Modules.ShaderTools {
@@ -19,6 +19,7 @@ namespace RegionKit.Modules.ShaderTools {
 				RenderTexture rt = Futile.screen.renderTexture;
 				if (rt.depth < DEPTH_AND_STENCIL_BUFFER_BITS) {
 					// Use this check in case another mod happens to enable the 32 bit buffer for whatever reason.
+					rt.Release();
 					rt.depth = DEPTH_AND_STENCIL_BUFFER_BITS;
 				}
 			}
@@ -34,14 +35,24 @@ namespace RegionKit.Modules.ShaderTools {
 		
 		private static void OnReinitializeRT(On.FScreen.orig_ReinitRenderTexture originalMethod, FScreen @this, int displayWidth) {
 			originalMethod(@this, displayWidth);
+			@this.renderTexture.Release();
 			// Use this check in case another mod happens to enable the 32 bit buffer for whatever reason.
-			@this.renderTexture.depth = (_hasStencilBuffer && @this.renderTexture.depth < DEPTH_AND_STENCIL_BUFFER_BITS) ? DEPTH_AND_STENCIL_BUFFER_BITS : @this.renderTexture.depth;
+			int newDepth = (_hasStencilBuffer && @this.renderTexture.depth < DEPTH_AND_STENCIL_BUFFER_BITS) ? DEPTH_AND_STENCIL_BUFFER_BITS : @this.renderTexture.depth;
+			if (@this.renderTexture.depth != newDepth) {
+				@this.renderTexture.Release();
+				@this.renderTexture.depth = newDepth;
+			}			
 		}
 
 		private static void OnConstructingFScreen(On.FScreen.orig_ctor originalCtor, FScreen @this, FutileParams futileParams) {
 			originalCtor(@this, futileParams);
 			// Use this check in case another mod happens to enable the 32 bit buffer for whatever reason.
-			@this.renderTexture.depth = (_hasStencilBuffer && @this.renderTexture.depth < DEPTH_AND_STENCIL_BUFFER_BITS) ? DEPTH_AND_STENCIL_BUFFER_BITS : @this.renderTexture.depth;
+			int newDepth = (_hasStencilBuffer && @this.renderTexture.depth < DEPTH_AND_STENCIL_BUFFER_BITS) ? DEPTH_AND_STENCIL_BUFFER_BITS : @this.renderTexture.depth;
+			if (@this.renderTexture.depth != newDepth)
+			{
+				@this.renderTexture.Release();
+				@this.renderTexture.depth = newDepth;
+			}
 		}
 
 	}

--- a/src/Modules/ShaderTools/ShaderBuffers.cs
+++ b/src/Modules/ShaderTools/ShaderBuffers.cs
@@ -8,13 +8,17 @@ namespace RegionKit.Modules.ShaderTools {
 		/// The amount of bits needed to activate the stencil buffer.
 		/// </summary>
 		private const int DEPTH_AND_STENCIL_BUFFER_BITS = 24;
+		
+		private static bool _hasStencilBuffer = false;
+		private static bool _initialized = false;
 
 		/// <summary>
 		/// Requests that the stencil buffer is enabled, setting the depth bit count of the main screen's render texture to 24 bits.
-    /// Once at least one mod calls this, it will be permanently enabled and 
+		/// Once at least one mod calls this, it will be permanently enabled and 
 		/// </summary>
 		public static void RequestStencilBuffer() {
-			if (Futile.screen != null) {
+			if (!_hasStencilBuffer && Futile.screen != null) {
+				_hasStencilBuffer = true;
 				RenderTexture rt = Futile.screen.renderTexture;
 				if (rt.depth < DEPTH_AND_STENCIL_BUFFER_BITS) {
 					rt.depth = DEPTH_AND_STENCIL_BUFFER_BITS;
@@ -23,18 +27,20 @@ namespace RegionKit.Modules.ShaderTools {
 		}
 
 		internal static void Initialize() {
+			if (_initialized) return;
+			_initialized = true;
 			On.FScreen.ctor += OnConstructingFScreen;
 			On.FScreen.ReinitRenderTexture += OnReinitializeRT;
 		}
-
+		
 		private static void OnReinitializeRT(On.FScreen.orig_ReinitRenderTexture originalMethod, FScreen @this, int displayWidth) {
 			originalMethod(@this, displayWidth);
-			@this.renderTexture.depth = _highestRequestedBits;
+			@this.renderTexture.depth = _hasStencilBuffer ? DEPTH_AND_STENCIL_BUFFER_BITS : @this.renderTexture.depth;
 		}
 
 		private static void OnConstructingFScreen(On.FScreen.orig_ctor originalCtor, FScreen @this, FutileParams futileParams) {
 			originalCtor(@this, futileParams);
-			@this.renderTexture.depth = _highestRequestedBits;
+			@this.renderTexture.depth = _hasStencilBuffer ? DEPTH_AND_STENCIL_BUFFER_BITS : @this.renderTexture.depth;
 		}
 
 	}

--- a/src/Modules/ShaderTools/ShaderBuffers.cs
+++ b/src/Modules/ShaderTools/ShaderBuffers.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using UnityEngine;
 
 namespace RegionKit.Modules.ShaderTools {
@@ -15,13 +15,6 @@ namespace RegionKit.Modules.ShaderTools {
 			On.FScreen.ctor += OnConstructingFScreen;
 			On.FScreen.ReinitRenderTexture += OnReinitializeRT;
 			_hasStencilBuffer = true;
-			if (Futile.screen != null) {
-				RenderTexture rt = Futile.screen.renderTexture;
-				if (rt.depth < DEPTH_AND_STENCIL_BUFFER_BITS) {
-					// Use this check in case another mod happens to enable the 32 bit buffer for whatever reason.
-					rt.depth = DEPTH_AND_STENCIL_BUFFER_BITS;
-				}
-			}
 		}
 
 		internal static void Uninitialize() {

--- a/src/Modules/ShaderTools/_Module.cs
+++ b/src/Modules/ShaderTools/_Module.cs
@@ -1,0 +1,24 @@
+﻿namespace RegionKit.Modules.ShaderTools {
+	[RegionKitModule(nameof(Enable), nameof(Disable), moduleName: "Shader Tools")]
+	public static class _Module {
+		/// <summary>
+		/// Applies hooks.
+		/// </summary>
+		public static void Enable() {
+			ShaderBuffers.Initialize();
+		}
+
+		/// <summary>
+		/// Undoes hooks.
+		/// </summary>
+		public static void Disable() {
+			// This probably should *not* be implemented.
+			// Editing the RT's bits has no adverse effects:
+			// 1. Depth doesn't work because *Unity* only renders the game's RT, and nothing else.
+			// 2. The stencil buffer is never set by any native shaders, meaning it is all 0 anyway by default.
+			
+			// And in exchange, disabling the buffer might brick compatibility with other mods that 
+			// enable it on their own, by unexpectedly disabling it when they might be trying to use it.
+		}
+	}
+}

--- a/src/Modules/ShaderTools/_Module.cs
+++ b/src/Modules/ShaderTools/_Module.cs
@@ -1,4 +1,6 @@
-﻿namespace RegionKit.Modules.ShaderTools {
+﻿using System;
+
+namespace RegionKit.Modules.ShaderTools {
 	[RegionKitModule(nameof(Enable), nameof(Disable), moduleName: "Shader Tools")]
 	public static class _Module {
 		/// <summary>

--- a/src/Modules/ShaderTools/_Module.cs
+++ b/src/Modules/ShaderTools/_Module.cs
@@ -12,13 +12,7 @@
 		/// Undoes hooks.
 		/// </summary>
 		public static void Disable() {
-			// This probably should *not* be implemented.
-			// Editing the RT's bits has no adverse effects:
-			// 1. Depth doesn't work because *Unity* only renders the game's RT, and nothing else.
-			// 2. The stencil buffer is never set by any native shaders, meaning it is all 0 anyway by default.
-			
-			// And in exchange, disabling the buffer might brick compatibility with other mods that 
-			// enable it on their own, by unexpectedly disabling it when they might be trying to use it.
+			ShaderBuffers.Uninitialize();
 		}
 	}
 }

--- a/src/RegionKit.csproj
+++ b/src/RegionKit.csproj
@@ -11,8 +11,8 @@
 		<Authors>RegionKit team</Authors>
 		<Description>All-in-one custom region dependency library.</Description>
 		<Copyright>GPL v3</Copyright>
-		<FileVersion>3.13</FileVersion>
-		<AssemblyVersion>3.13</AssemblyVersion>
+		<FileVersion>3.13.1</FileVersion>
+		<AssemblyVersion>3.13.1</AssemblyVersion>
 		<PackageReadmeFile>../README.md</PackageReadmeFile>
 		<PackageLicenseFile>../LICENSE</PackageLicenseFile>
 		<DebugType>Portable</DebugType>

--- a/src/RegionKit.csproj
+++ b/src/RegionKit.csproj
@@ -11,8 +11,8 @@
 		<Authors>RegionKit team</Authors>
 		<Description>All-in-one custom region dependency library.</Description>
 		<Copyright>GPL v3</Copyright>
-		<FileVersion>3.13.1</FileVersion>
-		<AssemblyVersion>3.13.1</AssemblyVersion>
+		<FileVersion>3.13.2</FileVersion>
+		<AssemblyVersion>3.13.2</AssemblyVersion>
 		<PackageReadmeFile>../README.md</PackageReadmeFile>
 		<PackageLicenseFile>../LICENSE</PackageLicenseFile>
 		<DebugType>Portable</DebugType>


### PR DESCRIPTION
This change crossports a feature from my own library that allows modders to enable the Stencil Buffer for use in custom shaders.

Implementation details:
- It has been implemented as a module, so that mods can use it on demand.
- It works with other buffer changes in mind, such that if anyone adds more detail to the buffer (via a higher bit depth) then this will not reduce the value.
  - It will always increase the value, as larger values implicitly contain all smaller values.