### PR TITLE
Decal Previewer

### DIFF
--- a/src/Modules/Misc/DecalPreview.cs
+++ b/src/Modules/Misc/DecalPreview.cs
@@ -79,19 +79,20 @@ internal static class DecalPreview
 	private static void GetDecalSources()
 	{
 		decalSources.Clear();
-		string[] array = AssetManager.ListDirectory("decals", false, false);
+
+		string[] allDecalPaths = AssetManager.ListDirectory("decals", false, false);
 
 		HashSet<string> decalDirectories = new HashSet<string>();
 
-		for (int i = 0; i < array.Length; i++)
+		for (int i = 0; i < allDecalPaths.Length; i++)
 		{
-			if (Directory.GetParent(array[i]).Parent.Name == "streamingassets")
+			if (Directory.GetParent(allDecalPaths[i]).Parent.Name == "streamingassets")
 			{
-				decalSources[Path.GetFileNameWithoutExtension(array[i])] = "Vanilla";
+				decalSources[Path.GetFileNameWithoutExtension(allDecalPaths[i])] = "Vanilla";
 				continue;
 			}
 
-			decalDirectories.Add(Directory.GetParent(array[i]).Parent.FullName);
+			decalDirectories.Add(Directory.GetParent(allDecalPaths[i]).Parent.FullName);
 		}
 
 		Dictionary<string, string> pathToModName = new Dictionary<string, string>();
@@ -101,11 +102,11 @@ internal static class DecalPreview
 			pathToModName[directory] = (string)modinfoJson["name"];
 		}
 
-		for (int i = 0; i < array.Length; i++)
+		for (int i = 0; i < allDecalPaths.Length; i++)
 		{
-			if (!decalSources.ContainsKey(Path.GetFileNameWithoutExtension(array[i])))
+			if (!decalSources.ContainsKey(Path.GetFileNameWithoutExtension(allDecalPaths[i])))
 			{
-				decalSources[Path.GetFileNameWithoutExtension(array[i])] = pathToModName[Directory.GetParent(array[i]).Parent.FullName];
+				decalSources[Path.GetFileNameWithoutExtension(allDecalPaths[i])] = pathToModName[Directory.GetParent(allDecalPaths[i]).Parent.FullName];
 			}
 		}
 	}

--- a/src/Modules/Misc/DecalPreview.cs
+++ b/src/Modules/Misc/DecalPreview.cs
@@ -62,17 +62,15 @@ internal static class DecalPreview
 
 	private static void CustomDecal_LoadFile(On.CustomDecal.orig_LoadFile orig, CustomDecal self, string fileName)
 	{
-		if (Futile.atlasManager.GetAtlasWithName(fileName) != null)
+		if (Futile.atlasManager.GetAtlasWithName(fileName) == null)
 		{
-			return;
-		}
+			string decalPath = AssetManager.ResolveFilePath("Decals" + Path.DirectorySeparatorChar.ToString() + fileName + ".png");
 
-		string decalPath = AssetManager.ResolveFilePath("Decals" + Path.DirectorySeparatorChar.ToString() + fileName + ".png");
-
-		if (!File.Exists(decalPath))
-		{
-			(self.placedObject.data as PlacedObject.CustomDecalData).imageName = "ph";
-			fileName = "ph";
+			if (!File.Exists(decalPath))
+			{
+				(self.placedObject.data as PlacedObject.CustomDecalData).imageName = "ph";
+				fileName = "ph";
+			}
 		}
 
 		orig(self, fileName);

--- a/src/Modules/Misc/DecalPreview.cs
+++ b/src/Modules/Misc/DecalPreview.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DevInterface;
+
+namespace RegionKit.Modules.Misc;
+
+internal static class DecalPreview
+{
+	public static void Enable()
+	{
+		On.DevInterface.Panel.Update += Panel_Update;
+		On.DevInterface.CustomDecalRepresentation.SelectDecalPanel.PopulateDecals += SelectDecalPanel_PopulateDecals;
+	}
+
+	public static void Disable()
+	{
+		On.DevInterface.Panel.Update -= Panel_Update;
+		On.DevInterface.CustomDecalRepresentation.SelectDecalPanel.PopulateDecals -= SelectDecalPanel_PopulateDecals;
+	}
+
+	private static void Panel_Update(On.DevInterface.Panel.orig_Update orig, Panel self)
+	{
+		orig(self);
+
+		if (self is not CustomDecalRepresentation.SelectDecalPanel) return;
+
+		foreach (var subNode in self.subNodes)
+		{
+			if (subNode is Button && (subNode as Button).MouseOver)
+			{
+				if (subNode.IDstring == "BackPage99289..?/~") continue;
+				if (subNode.IDstring == "NextPage99289..?/~") continue;
+
+				(self.parentNode.parentNode as CustomDecalRepresentation).CD.LoadFile(subNode.IDstring);
+
+				if (Futile.atlasManager.GetAtlasWithName(subNode.IDstring) != null)
+				{
+					self.fSprites[7].SetElementByName(subNode.IDstring);
+					self.fSprites[7].isVisible = true;
+
+					return;
+				}
+			}
+		}
+
+		self.fSprites[7].isVisible = false;
+	}
+
+	private static void SelectDecalPanel_PopulateDecals(On.DevInterface.CustomDecalRepresentation.SelectDecalPanel.orig_PopulateDecals orig, CustomDecalRepresentation.SelectDecalPanel self, int offset)
+	{
+		orig(self, offset);
+
+		//string[] array = AssetManager.ListDirectory("decals", false, false);
+
+		//for (int i = 0; i < array.Length; i++)
+		//{
+		//	Debug.Log(array[i]);
+		//}
+
+		if (self.fSprites.Count != 8) self.fSprites.Add(new FSprite("pixel"));
+		self.fSprites[7].anchorX = 0f;
+		self.fSprites[7].anchorY = 0f;
+		Futile.stage.AddChild(self.fSprites[7]);
+	}
+}

--- a/src/Modules/Misc/DecalPreview.cs
+++ b/src/Modules/Misc/DecalPreview.cs
@@ -12,12 +12,17 @@ internal static class DecalPreview
 	{
 		On.DevInterface.Panel.Update += Panel_Update;
 		On.DevInterface.ObjectsPage.ctor += ObjectsPage_ctor;
+
+		// Fixes exception when trying to load decal that doesn't exist, tought i could throw that in
+		On.CustomDecal.LoadFile += CustomDecal_LoadFile;
 	}
 
 	public static void Disable()
 	{
 		On.DevInterface.Panel.Update -= Panel_Update;
 		On.DevInterface.ObjectsPage.ctor -= ObjectsPage_ctor;
+
+		On.CustomDecal.LoadFile -= CustomDecal_LoadFile;
 	}
 
 	private static void Panel_Update(On.DevInterface.Panel.orig_Update orig, Panel self)
@@ -53,6 +58,24 @@ internal static class DecalPreview
 		self.subNodes.Add(new DecalPreviewOverlay(owner, "DecalPreviewOverlay", self));
 
 		GetDecalSources();
+	}
+
+	private static void CustomDecal_LoadFile(On.CustomDecal.orig_LoadFile orig, CustomDecal self, string fileName)
+	{
+		if (Futile.atlasManager.GetAtlasWithName(fileName) != null)
+		{
+			return;
+		}
+
+		string decalPath = AssetManager.ResolveFilePath("Decals" + Path.DirectorySeparatorChar.ToString() + fileName + ".png");
+
+		if (!File.Exists(decalPath))
+		{
+			(self.placedObject.data as PlacedObject.CustomDecalData).imageName = "ph";
+			fileName = "ph";
+		}
+
+		orig(self, fileName);
 	}
 
 	private static void GetDecalSources()

--- a/src/Modules/Misc/_Module.cs
+++ b/src/Modules/Misc/_Module.cs
@@ -21,6 +21,7 @@ internal static class _Module
 		SlugcatRoomTemplates.Apply();
 		RainSong.Enable();
 		FadePaletteCombiner.Enable();
+		DecalPreview.Enable();
 	}
 	public static void Disable()
 	{
@@ -33,5 +34,6 @@ internal static class _Module
 		SlugcatRoomTemplates.Undo();
 		RainSong.Disable();
 		FadePaletteCombiner.Disable();
+		DecalPreview.Disable();
 	}
 }


### PR DESCRIPTION
Adds a preview window when hovering over a decal button for CustomDecals. Also shows if the decal is from vanilla or from a mod and the size of the decal. Also includes a fix for the exception caused by the game trying to load a decal that doesn't exist.