### PR TITLE
Update ReplaceCorruptionColor.cs to fix a missing null check

### DIFF
--- a/src/Modules/Effects/ReplaceCorruptionColor.cs
+++ b/src/Modules/Effects/ReplaceCorruptionColor.cs
@@ -107,7 +107,7 @@ namespace RegionKit.Modules.Effects
 					self.ApplyPalette(sLeaser, rCam, rCam.currentPalette);
 				}
 			}
-			else if (corruptionCWT.TryGetValue(self.daddy.room, out CorruptionValues corruptionValues))
+			else if (self.daddy.abstractCreature.room != null && corruptionCWT.TryGetValue(self.daddy.abstractCreature.room, out CorruptionValues corruptionValues))
 			{
 				dllCWT.Add(self.daddy.abstractCreature, corruptionValues);
 			}


### PR DESCRIPTION
Someone reported this to me and I realized I forgot to add a room null check for instances like Mouse Drag where you can delete the creature before it's graphics module is destroyed in the same frame, which causes the room to be null.