### PR TITLE
Attempt to fix integrated effect color in palette room effect by forcing the game to reload the palette images

### DIFF
--- a/src/Modules/Misc/MoreFadePalettes.cs
+++ b/src/Modules/Misc/MoreFadePalettes.cs
@@ -337,12 +337,16 @@ internal static class MoreFadePalettes
 		RoomSettings.RoomEffect roomEffect = self.room?.roomSettings.GetEffect(PaletteEffectColorA);
 		if (roomEffect != null)
 		{
-			FadeEffectColor(self, 4);
+			FadeEffectColor(self, 4); 
+			self.LoadPalette(self.room.roomSettings.Palette, ref self.fadeTexA);
+			self.LoadPalette(self.room.roomSettings.fadePalette.palette, ref self.fadeTexB);
 		}
 		roomEffect = self.room?.roomSettings.GetEffect(PaletteEffectColorB);
 		if (roomEffect != null)
 		{
 			FadeEffectColor(self, 2);
+			self.LoadPalette(self.room.roomSettings.Palette, ref self.fadeTexA);
+			self.LoadPalette(self.room.roomSettings.fadePalette.palette, ref self.fadeTexB);
 		}
 
 		orig(self, color1, color2);


### PR DESCRIPTION
Lazy fix for the issue people have been having with the PaletteEffectColor(A/B) effect objects. I can't be bothered to logic check MoreFadePalettes at the moment, but hopefully at least this will resolve the issue people are having with it not working when switching rooms.